### PR TITLE
Add switch to hide up-to-date exercises

### DIFF
--- a/src/components/SwitchToggle.tsx
+++ b/src/components/SwitchToggle.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+interface Props {
+  activeLabel: string
+  inActiveLabel: string
+  onToggle: () => void
+  actionableOnly: boolean
+}
+
+export function SwitchToggle({
+  activeLabel,
+  inActiveLabel,
+  onToggle,
+  actionableOnly,
+}: Props) {
+  return (
+    <div className="custom-control custom-switch" onClick={onToggle}>
+      <input
+        type="checkbox"
+        className="custom-control-input"
+        checked={actionableOnly}
+        readOnly
+      />
+      <label className="custom-control-label">
+        {actionableOnly ? activeLabel : inActiveLabel}
+      </label>
+    </div>
+  )
+}

--- a/src/components/TrackAside.tsx
+++ b/src/components/TrackAside.tsx
@@ -4,79 +4,68 @@ import { useTrackAsideData } from '../hooks/useTrackData'
 import { LoadingIconWithPopover } from './Popover'
 import { useToggleState } from '../hooks/useToggleState'
 import { useKeyPressListener } from '../hooks/useKeyListener'
+import { useActionableState } from '../hooks/useActionableOnly'
 
-export function TrackAside({
-  trackId,
-  actionableOnly,
-}: {
+export interface TrackAsideProps {
   trackId: TrackIdentifier
-  actionableOnly: boolean
-}) {
+}
+
+export function TrackAside({ trackId }: TrackAsideProps) {
   const { done: doneConfig, config } = useRemoteConfig(trackId)
   const { done, data } = useTrackAsideData(trackId)
+  const [actionableOnly] = useActionableState()
+
   const [activeDetailsKey, setActiveDetailsKey] = useToggleState<
     HTMLUListElement
   >(undefined, 'popover', 'popover-toggle')
 
   useKeyPressListener(['Esc', 'Escape'], setActiveDetailsKey)
 
-  const normConfigVisible = !!config !== actionableOnly
-  const automatedAnalysisVisible =
-    (actionableOnly && data['analyzer'] === false) || !actionableOnly
-  const testRunnerVisible =
-    (actionableOnly && data['testRunner'] === false) || !actionableOnly
-
-    return (
+  return (
     <aside className="mt-md-4 mb-4 col-md">
       <ul className="list-group" style={{ whiteSpace: 'nowrap' }}>
         <li className="list-group-item d-flex justify-content-between">
           <RepositoryLink repository={trackId}>Repository</RepositoryLink>
         </li>
-        {normConfigVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            <a
-              href={`https://github.com/exercism/${trackId}/blob/master/config.json`}
-              className="d-block mr-4"
-            >
-              Normalized Configuration
-            </a>
+        <AsideItem disabled={actionableOnly && !!config}>
+          <a
+            href={`https://github.com/exercism/${trackId}/blob/master/config.json`}
+            className="d-block mr-4"
+          >
+            Normalized Configuration
+          </a>
 
-            <ConfigurationIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('config.json')}
-              loading={!doneConfig}
-              valid={!!config}
-            />
-          </li>
-        )}
-        {automatedAnalysisVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            <RepositoryLink repository={`${trackId}-analyzer`}>
-              Automated Analysis
-            </RepositoryLink>
-            <AnalyzerIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('analyzer')}
-              trackId={trackId}
-              loading={!done}
-              valid={data['analyzer'] === true}
-            />
-          </li>
-        )}
-        {testRunnerVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            <RepositoryLink repository={`${trackId}-test-runner`}>
-              Test Runner
-            </RepositoryLink>
-            <TestRunnerIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('test-runner')}
-              trackId={trackId}
-              loading={!done}
-              valid={data['testRunner'] === true}
-            />
-          </li>
-        )}
+          <ConfigurationIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('config.json')}
+            loading={!doneConfig}
+            valid={!!config}
+          />
+        </AsideItem>
+        <AsideItem disabled={actionableOnly && data['analyzer'] === true}>
+          <RepositoryLink repository={`${trackId}-analyzer`}>
+            Automated Analysis
+          </RepositoryLink>
+          <AnalyzerIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('analyzer')}
+            trackId={trackId}
+            loading={!done}
+            valid={data['analyzer'] === true}
+          />
+        </AsideItem>
+        <AsideItem disabled={actionableOnly && data['testRunner'] === true}>
+          <RepositoryLink repository={`${trackId}-test-runner`}>
+            Test Runner
+          </RepositoryLink>
+          <TestRunnerIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('test-runner')}
+            trackId={trackId}
+            loading={!done}
+            valid={data['testRunner'] === true}
+          />
+        </AsideItem>
       </ul>
 
       {done && data['analyzer'] === true && (
@@ -92,6 +81,24 @@ export function TrackAside({
         </ul>
       )}
     </aside>
+  )
+}
+
+function AsideItem({
+  disabled,
+  children,
+}: {
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <li
+      className={`list-group-item d-flex justify-content-between ${
+        disabled ? 'not-actionable' : ''
+      }`}
+    >
+      {children}
+    </li>
   )
 }
 

--- a/src/components/TrackAside.tsx
+++ b/src/components/TrackAside.tsx
@@ -5,7 +5,13 @@ import { LoadingIconWithPopover } from './Popover'
 import { useToggleState } from '../hooks/useToggleState'
 import { useKeyPressListener } from '../hooks/useKeyListener'
 
-export function TrackAside({ trackId }: { trackId: TrackIdentifier }) {
+export function TrackAside({
+  trackId,
+  actionableOnly,
+}: {
+  trackId: TrackIdentifier
+  actionableOnly: boolean
+}) {
   const { done: doneConfig, config } = useRemoteConfig(trackId)
   const { done, data } = useTrackAsideData(trackId)
   const [activeDetailsKey, setActiveDetailsKey] = useToggleState<
@@ -14,51 +20,63 @@ export function TrackAside({ trackId }: { trackId: TrackIdentifier }) {
 
   useKeyPressListener(['Esc', 'Escape'], setActiveDetailsKey)
 
-  return (
+  const normConfigVisible = !!config !== actionableOnly
+  const automatedAnalysisVisible =
+    (actionableOnly && data['analyzer'] === false) || !actionableOnly
+  const testRunnerVisible =
+    (actionableOnly && data['testRunner'] === false) || !actionableOnly
+
+    return (
     <aside className="mt-md-4 mb-4 col-md">
       <ul className="list-group" style={{ whiteSpace: 'nowrap' }}>
         <li className="list-group-item d-flex justify-content-between">
           <RepositoryLink repository={trackId}>Repository</RepositoryLink>
         </li>
-        <li className="list-group-item d-flex justify-content-between">
-          <a
-            href={`https://github.com/exercism/${trackId}/blob/master/config.json`}
-            className="d-block mr-4"
-          >
-            Normalized Configuration
-          </a>
+        {normConfigVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            <a
+              href={`https://github.com/exercism/${trackId}/blob/master/config.json`}
+              className="d-block mr-4"
+            >
+              Normalized Configuration
+            </a>
 
-          <ConfigurationIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('config.json')}
-            loading={!doneConfig}
-            valid={!!config}
-          />
-        </li>
-        <li className="list-group-item d-flex justify-content-between">
-          <RepositoryLink repository={`${trackId}-analyzer`}>
-            Automated Analysis
-          </RepositoryLink>
-          <AnalyzerIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('analyzer')}
-            trackId={trackId}
-            loading={!done}
-            valid={data['analyzer'] === true}
-          />
-        </li>
-        <li className="list-group-item d-flex justify-content-between">
-          <RepositoryLink repository={`${trackId}-test-runner`}>
-            Test Runner
-          </RepositoryLink>
-          <TestRunnerIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('test-runner')}
-            trackId={trackId}
-            loading={!done}
-            valid={data['testRunner'] === true}
-          />
-        </li>
+            <ConfigurationIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('config.json')}
+              loading={!doneConfig}
+              valid={!!config}
+            />
+          </li>
+        )}
+        {automatedAnalysisVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            <RepositoryLink repository={`${trackId}-analyzer`}>
+              Automated Analysis
+            </RepositoryLink>
+            <AnalyzerIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('analyzer')}
+              trackId={trackId}
+              loading={!done}
+              valid={data['analyzer'] === true}
+            />
+          </li>
+        )}
+        {testRunnerVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            <RepositoryLink repository={`${trackId}-test-runner`}>
+              Test Runner
+            </RepositoryLink>
+            <TestRunnerIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('test-runner')}
+              trackId={trackId}
+              loading={!done}
+              valid={data['testRunner'] === true}
+            />
+          </li>
+        )}
       </ul>
 
       {done && data['analyzer'] === true && (

--- a/src/components/TrackChecklist.tsx
+++ b/src/components/TrackChecklist.tsx
@@ -3,80 +3,85 @@ import { useTrackAsideData } from '../hooks/useTrackData'
 import { LoadingIconWithPopover } from './Popover'
 import { useToggleState } from '../hooks/useToggleState'
 import { useKeyPressListener } from '../hooks/useKeyListener'
+import { useActionableState } from '../hooks/useActionableOnly'
 
-export const TrackChecklist = ({
-  trackId,
-  actionableOnly,
-}: {
-  trackId: TrackIdentifier
-  actionableOnly: boolean
-}) => {
+export const TrackChecklist = ({ trackId }: { trackId: TrackIdentifier }) => {
   const { done, checklist } = useTrackAsideData(trackId)
   const [activeDetailsKey, setActiveDetailsKey] = useToggleState(
     undefined,
     'popover',
     'popover-toggle'
   )
+  const [actionableOnly] = useActionableState()
 
   useKeyPressListener(['Esc', 'Escape'], setActiveDetailsKey)
-
-  const blurbVisible = (actionableOnly && checklist.hasBlurb) || !actionableOnly
-  const autoApproveVisible =
-    (actionableOnly && checklist.hasAutoApprove) || !actionableOnly
-  const coreVisible =
-    (actionableOnly && checklist.exerciseCoreCount > 0) || !actionableOnly
-  const topicsVisible =
-    (actionableOnly && checklist.exerciseWithTopicsCount > 0) || !actionableOnly
 
   return (
     <aside className="mt-md-4 mb-4 col-md">
       <ul className="list-group" style={{ whiteSpace: 'nowrap' }}>
-        {blurbVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            Track blurb
-            <BlurbIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('blurb')}
-              loading={!done}
-              valid={checklist.hasBlurb}
-            />
-          </li>
-        )}
-        {autoApproveVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            Auto approve exercise
-            <AutoApproveIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('auto-approve')}
-              loading={!done}
-              valid={checklist.hasAutoApprove}
-            />
-          </li>
-        )}
-        {coreVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            Exercises in core
-            <CoreIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('core')}
-              loading={!done}
-              valid={checklist.exerciseCoreCount > 0}
-            />
-          </li>
-        )}
-        {topicsVisible && (
-          <li className="list-group-item d-flex justify-content-between">
-            Exercises with topics
-            <TopicsIcon
-              currentDetails={activeDetailsKey}
-              onToggleDetails={() => setActiveDetailsKey('topics')}
-              loading={!done}
-              valid={checklist.exerciseWithTopicsCount > 0}
-            />
-          </li>
-        )}
+        <ChecklistItem disabled={actionableOnly && checklist.hasBlurb}>
+          Track blurb
+          <BlurbIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('blurb')}
+            loading={!done}
+            valid={checklist.hasBlurb}
+          />
+        </ChecklistItem>
+
+        <ChecklistItem disabled={actionableOnly && checklist.hasAutoApprove}>
+          Auto approve exercise
+          <AutoApproveIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('auto-approve')}
+            loading={!done}
+            valid={checklist.hasAutoApprove}
+          />
+        </ChecklistItem>
+
+        <ChecklistItem
+          disabled={actionableOnly && checklist.exerciseCoreCount > 0}
+        >
+          Exercises in core {done ? `(${checklist.exerciseCoreCount})` : ''}
+          <CoreIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('core')}
+            loading={!done}
+            valid={checklist.exerciseCoreCount > 0}
+          />
+        </ChecklistItem>
+
+        <ChecklistItem
+          disabled={actionableOnly && checklist.exerciseWithTopicsCount > 0}
+        >
+          Exercises with topics
+          <TopicsIcon
+            currentDetails={activeDetailsKey}
+            onToggleDetails={() => setActiveDetailsKey('topics')}
+            loading={!done}
+            valid={checklist.exerciseWithTopicsCount > 0}
+          />
+        </ChecklistItem>
       </ul>
     </aside>
+  )
+}
+
+function ChecklistItem({
+  disabled,
+  children,
+}: {
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <li
+      className={`list-group-item d-flex justify-content-between ${
+        disabled ? 'not-actionable' : ''
+      }`}
+    >
+      {children}
+    </li>
   )
 }
 

--- a/src/components/TrackChecklist.tsx
+++ b/src/components/TrackChecklist.tsx
@@ -4,7 +4,13 @@ import { LoadingIconWithPopover } from './Popover'
 import { useToggleState } from '../hooks/useToggleState'
 import { useKeyPressListener } from '../hooks/useKeyListener'
 
-export const TrackChecklist = ({ trackId }: { trackId: TrackIdentifier }) => {
+export const TrackChecklist = ({
+  trackId,
+  actionableOnly,
+}: {
+  trackId: TrackIdentifier
+  actionableOnly: boolean
+}) => {
   const { done, checklist } = useTrackAsideData(trackId)
   const [activeDetailsKey, setActiveDetailsKey] = useToggleState(
     undefined,
@@ -14,45 +20,61 @@ export const TrackChecklist = ({ trackId }: { trackId: TrackIdentifier }) => {
 
   useKeyPressListener(['Esc', 'Escape'], setActiveDetailsKey)
 
+  const blurbVisible = (actionableOnly && checklist.hasBlurb) || !actionableOnly
+  const autoApproveVisible =
+    (actionableOnly && checklist.hasAutoApprove) || !actionableOnly
+  const coreVisible =
+    (actionableOnly && checklist.exerciseCoreCount > 0) || !actionableOnly
+  const topicsVisible =
+    (actionableOnly && checklist.exerciseWithTopicsCount > 0) || !actionableOnly
+
   return (
     <aside className="mt-md-4 mb-4 col-md">
       <ul className="list-group" style={{ whiteSpace: 'nowrap' }}>
-        <li className="list-group-item d-flex justify-content-between">
-          Track blurb
-          <BlurbIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('blurb')}
-            loading={!done}
-            valid={checklist.hasBlurb}
-          />
-        </li>
-        <li className="list-group-item d-flex justify-content-between">
-          Auto approve exercise
-          <AutoApproveIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('auto-approve')}
-            loading={!done}
-            valid={checklist.hasAutoApprove}
-          />
-        </li>
-        <li className="list-group-item d-flex justify-content-between">
-          Exercises in core
-          <CoreIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('core')}
-            loading={!done}
-            valid={checklist.exerciseCoreCount > 0}
-          />
-        </li>
-        <li className="list-group-item d-flex justify-content-between">
-          Exercises with topics
-          <TopicsIcon
-            currentDetails={activeDetailsKey}
-            onToggleDetails={() => setActiveDetailsKey('topics')}
-            loading={!done}
-            valid={checklist.exerciseWithTopicsCount > 0}
-          />
-        </li>
+        {blurbVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            Track blurb
+            <BlurbIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('blurb')}
+              loading={!done}
+              valid={checklist.hasBlurb}
+            />
+          </li>
+        )}
+        {autoApproveVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            Auto approve exercise
+            <AutoApproveIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('auto-approve')}
+              loading={!done}
+              valid={checklist.hasAutoApprove}
+            />
+          </li>
+        )}
+        {coreVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            Exercises in core
+            <CoreIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('core')}
+              loading={!done}
+              valid={checklist.exerciseCoreCount > 0}
+            />
+          </li>
+        )}
+        {topicsVisible && (
+          <li className="list-group-item d-flex justify-content-between">
+            Exercises with topics
+            <TopicsIcon
+              currentDetails={activeDetailsKey}
+              onToggleDetails={() => setActiveDetailsKey('topics')}
+              loading={!done}
+              valid={checklist.exerciseWithTopicsCount > 0}
+            />
+          </li>
+        )}
       </ul>
     </aside>
   )

--- a/src/components/TrackTool.tsx
+++ b/src/components/TrackTool.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, MouseEvent, useMemo } from 'react'
+import React, { useCallback, useState, MouseEvent } from 'react'
 
 import { useTrackData } from '../hooks/useTrackData'
 import { useRemoteConfig } from '../hooks/useRemoteConfig'
@@ -6,7 +6,7 @@ import { TrackAside } from './TrackAside'
 import { TrackChecklist } from './TrackChecklist'
 import { TrackDescription } from './TrackDescription'
 import { TrackIcon } from './TrackIcon'
-
+import { SwitchToggle } from './SwitchToggle'
 import { ExerciseDetails } from './views/ExerciseDetails'
 import { TrackMissing } from './views/TrackMissing'
 import { TrackTopics } from './views/TrackTopics'
@@ -25,7 +25,7 @@ export function TrackTool({
   onUnselect,
 }: TrackToolProps): JSX.Element {
   const [selectedView] = useView()
-
+  const [actionableOnly, setActionableOnly] = useState<boolean>(false)
   const actualView = selectedView || DEFAULT_VIEW
 
   const doHideExercise = useCallback(() => {
@@ -55,16 +55,23 @@ export function TrackTool({
 
   return (
     <section>
-      <UnselectTrackButton onClick={onUnselect} />
+      <div className="d-flex justify-content-start flex-row align-items-center w-50">
+        <UnselectTrackButton onClick={onUnselect} />
+        <SwitchToggle
+          inActiveLabel="All"
+          activeLabel="Actionable"
+          onToggle={() => setActionableOnly((prev) => !prev)}
+          actionableOnly={actionableOnly}
+        />
+      </div>
 
       <div className="d-flex flex-wrap row">
         <div className="col" style={{ maxWidth: '27rem' }}>
           <Header trackId={trackId} />
         </div>
-        <TrackAside trackId={trackId} />
-        <TrackChecklist trackId={trackId} />
+        <TrackAside trackId={trackId} actionableOnly={actionableOnly} />
+        <TrackChecklist trackId={trackId} actionableOnly={actionableOnly} />
       </div>
-
       <ViewSelect />
 
       <TrackView
@@ -134,7 +141,6 @@ function ViewSelectLink({
   return (
     <a
       className={`btn btn-sm btn-outline-primary ${active && 'active'} mb-3`}
-      aria-pressed={active}
       onClick={doChangeView}
       href={href}
     >

--- a/src/components/views/TrackTopics.tsx
+++ b/src/components/views/TrackTopics.tsx
@@ -8,6 +8,7 @@ import { ContainedPopover } from '../Popover'
 import { CheckOrCross } from '../CheckOrCross'
 import { ExerciseIcon } from '../ExerciseIcon'
 import { useKeyPressListener } from '../../hooks/useKeyListener'
+import { useActionableState } from '../../hooks/useActionableOnly'
 
 interface TrackTopicsProps {
   trackId: TrackIdentifier
@@ -229,6 +230,16 @@ function ExerciseRow({
     exercise,
     onShowExercise,
   ])
+
+  const [actionableOnly] = useActionableState()
+
+  if (actionableOnly) {
+    // Hide if all valid
+    const valid = !hasSuggestions
+    if (valid) {
+      return null
+    }
+  }
 
   return (
     <tr key={exercise.slug}>

--- a/src/components/views/TrackVersions.tsx
+++ b/src/components/views/TrackVersions.tsx
@@ -12,6 +12,7 @@ import { LoadingIndicator } from '../LoadingIndicator'
 import { ContainedPopover } from '../Popover'
 import { ExerciseIcon } from '../ExerciseIcon'
 import { useKeyPressListener } from '../../hooks/useKeyListener'
+import { useActionableState } from '../../hooks/useActionableOnly'
 
 interface TrackVersionsProps {
   trackId: TrackIdentifier
@@ -209,6 +210,21 @@ function ExerciseRow({
     () => onShowExercise(exercise.slug),
     [exercise, onShowExercise]
   )
+
+  const [actionableOnly] = useActionableState()
+
+  if (actionableOnly) {
+    // Don't show whilst loading
+    if (!remoteDone || !canonicalDone) {
+      return null
+    }
+
+    // Hide if up-to-date
+    const valid = testVersion(canonicalVersion, remoteVersion)
+    if (valid) {
+      return null
+    }
+  }
 
   return (
     <tr key={exercise.slug}>

--- a/src/hooks/useActionableOnly.ts
+++ b/src/hooks/useActionableOnly.ts
@@ -1,0 +1,20 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  SetStateAction,
+  Dispatch,
+} from 'react'
+
+type ActionableState = [boolean, Dispatch<SetStateAction<boolean>>]
+
+const ActionableContext = createContext<ActionableState>([false, () => {}])
+export const ProvideActionable = ActionableContext.Provider
+
+export function useProvideActionableState(): ActionableState {
+  return useState<boolean>(false)
+}
+
+export function useActionableState(): ActionableState {
+  return useContext(ActionableContext)
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,34 +1,3 @@
-/* Box sizing rules */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-/* Remove default padding */
-ul[class],
-ol[class] {
-  padding: 0;
-}
-
-/* Remove default margin */
-body,
-h1,
-h2,
-h3,
-h4,
-p,
-ul[class],
-ol[class],
-li,
-figure,
-figcaption,
-blockquote,
-dl,
-dd {
-  margin: 0;
-}
-
 /* Set core body defaults */
 body {
   min-height: 100vh;
@@ -37,17 +6,6 @@ body {
   line-height: 1.5;
 
   overflow-y: scroll;
-}
-
-/* Remove list styles on ul, ol elements with a class attribute */
-ul[class],
-ol[class] {
-  list-style: none;
-}
-
-/* A elements that don't have a class get default styles */
-a:not([class]) {
-  text-decoration-skip-ink: auto;
 }
 
 /* Make images easier to work with */
@@ -100,6 +58,10 @@ p {
   width: 300px;
   max-width: 300px;
   box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.12);
+}
+
+.not-actionable {
+  opacity: 0.4;
 }
 
 /* Debug focus! */


### PR DESCRIPTION
resolves #16 

NOTE: During this process I was running into a sporadic TS error occurring in the `useLocation` hook. I made sure it wasn't resulting from any changes I made lol. Specifically the type definition for `oldTrigger` in the `originalHistoryTriggers` function. However, I can't get it to consistently occur, which is confusing.

Resulting error (in FF):
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/36317675/66432734-c0572100-e9ec-11e9-948a-d60abb7f7397.png">
