### PR TITLE
Adds versioning for Delphi Track

### DIFF
--- a/src/data/tracks.json
+++ b/src/data/tracks.json
@@ -81,7 +81,8 @@
   {
     "slug": "delphi",
     "name": "Delphi Pascal",
-    "core_enabled": true
+    "core_enabled": true,
+    "versioning": "exercises/{slug}/u{ExerciseSlug}Tests.pas"
   },
   {
     "slug": "elm",


### PR DESCRIPTION
Test suites contain versioning information. I have not looked into if it conforms to any prescribed norms, it is just what I have been doing for myself while maintaining the track. Furthermore the test suite always contains the word `test` in the its filename, though sometimes it may be `Test` or `Tests`. Windows is not case sensitive on filenames. Hopefully wildcards are acceptable.