### PR TITLE
Add detail on Dart versioning

### DIFF
--- a/src/data/tracks.json
+++ b/src/data/tracks.json
@@ -76,7 +76,8 @@
   {
     "slug": "dart",
     "name": "Dart",
-    "core_enabled": true
+    "core_enabled": true,
+    "versioning": "exercises/{slug}/pubspec.yaml"
   },
   {
     "slug": "delphi",


### PR DESCRIPTION
Dart projects keep their versioning in `pubspec.yaml` files. All of our Dart exercises have that file already for dependency management.

Just adding a detail in tracks.json to point to that file for each exercise