### PR TITLE
Fixes typos, grammar, and invalid refs to "versions" key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # tracks-maintenance-dashboard
 
-A dashboard for maintainers to understand the state of tracks
+A dashboard to help maintainers understand the state of tracks.
 
 ## Track versioning
 
-Edit `src/data/tracks.json` and add `versioning` key. The value is _not_ a
+Add a `versioning` key to `/src/data/tracks.json`. The value is _not_ a
 regular expression or glob pattern, but allows for very specific template
 replacements:
 
@@ -15,11 +15,11 @@ replacements:
 
 ## Stub tracking
 
-Edit `src/data/tracks.json` and add `stub` key. The value is _not_ a
+Add a `versioning` key to `/src/data/tracks.json`. The value is _not_ a
 regular expression or glob pattern, but allows for very specific template
 replacements. Same as Track Versioning.
 
 ## Exercise "unactionable"
 
 In order to remove an exercise from the version table (marked as not in sync),
-add it to the `unactionable -> versions` list in `src/data/tracks.json`.
+add it to the `unactionable -> versioning` list in `src/data/tracks.json`.

--- a/src/components/views/TrackStubs.tsx
+++ b/src/components/views/TrackStubs.tsx
@@ -40,7 +40,7 @@ export function TrackStubs({
   )
 }
 
-const NO_EXCERCISES: ReadonlyArray<ExerciseConfiguration> = []
+const NO_EXERCISES: ReadonlyArray<ExerciseConfiguration> = []
 const NO_FOREGONE_EXERCISES: ReadonlyArray<string> = []
 
 interface ExerciseTableProps {
@@ -378,7 +378,7 @@ function useValidExercises(
   exercises: ReadonlyArray<ExerciseConfiguration>
 ) {
   if (!exercises) {
-    return NO_EXCERCISES
+    return NO_EXERCISES
   }
 
   return exercises.filter(
@@ -394,7 +394,7 @@ function useInvalidExercises(
   exercises: ReadonlyArray<ExerciseConfiguration>
 ) {
   if (!exercises) {
-    return { foregone, deprecated: NO_EXCERCISES }
+    return { foregone, deprecated: NO_EXERCISES }
   }
 
   return exercises.reduce(

--- a/src/components/views/TrackTopics.tsx
+++ b/src/components/views/TrackTopics.tsx
@@ -71,7 +71,7 @@ function TopicsFileLink({
   )
 }
 
-const NO_EXCERCISES: ReadonlyArray<ExerciseConfiguration> = []
+const NO_EXERCISES: ReadonlyArray<ExerciseConfiguration> = []
 const NO_FOREGONE_EXERCISES: ReadonlyArray<string> = []
 
 interface ExerciseTableProps {
@@ -347,7 +347,7 @@ function useValidExercises(
   exercises: ReadonlyArray<ExerciseConfiguration>
 ): readonly ExerciseConfiguration[] {
   if (!exercises) {
-    return NO_EXCERCISES
+    return NO_EXERCISES
   }
 
   return exercises.filter(

--- a/src/components/views/TrackVersions.tsx
+++ b/src/components/views/TrackVersions.tsx
@@ -45,7 +45,7 @@ export function TrackVersions({
   )
 }
 
-const NO_EXCERCISES: ReadonlyArray<ExerciseConfiguration> = []
+const NO_EXERCISES: ReadonlyArray<ExerciseConfiguration> = []
 const NO_FOREGONE_EXERCISES: ReadonlyArray<string> = []
 
 interface ExerciseTableProps {
@@ -141,8 +141,8 @@ function ExerciseTable({
                 different reason than being out of date, for example because its
                 canonical updates don't make sense for this track, open a PR to
                 change <a href={TRACKS_JSON_GITHUB_URL}>this file</a> and add
-                those exercise's <code>slug</code> to{' '}
-                <code>unactionable -> versions</code>.
+                each exercises' <code>slug</code> to{' '}
+                <code>unactionable -> versioning</code>.
               </p>
             </td>
           </tr>
@@ -387,7 +387,7 @@ function VersionsDontMatch(): JSX.Element {
       The version in the <code>exercism/problem-specifications</code> repository
       is higher than the local version. In order to resolve this, update the
       exercise by re-generating the <code>README.md</code> and updating the
-      exericse tests.
+      exercise tests.
     </p>
   )
 }
@@ -403,7 +403,7 @@ function WontFixIcon(): JSX.Element {
 function WontFixExplanation(): JSX.Element {
   return (
     <p className="mb-0">
-      This exercise has been added to the <code>unactionable -> versions</code>{' '}
+      This exercise has been added to the <code>unactionable -> versioning</code>{' '}
       list in <a href={TRACKS_JSON_GITHUB_URL}>this file</a> , which means it is
       marked to be never in sync with the canonical data. A common reason is
       that the canonical updates don't make sense for this track and therefore
@@ -422,7 +422,7 @@ function ForegoneSection({ exercises }: { exercises: ReadonlyArray<string> }): J
       <h3>Foregone</h3>
       <p>
         Exercises listed here have the <code>foregone</code> flag set to{' '}
-        <code>true</code>. This means that the track has <em>explicitely</em>{' '}
+        <code>true</code>. This means that the track has <em>explicitly</em>{' '}
         chosen to forego implementing this exercise.
       </p>
 
@@ -468,7 +468,7 @@ function useValidExercises(
   exercises: readonly ExerciseConfiguration[]
 ): readonly ExerciseConfiguration[] {
   if (!exercises) {
-    return NO_EXCERCISES
+    return NO_EXERCISES
   }
 
   return exercises.filter(
@@ -487,7 +487,7 @@ function useInvalidExercises(
   deprecated: readonly ExerciseConfiguration[]
 } {
   if (!exercises) {
-    return { foregone, deprecated: NO_EXCERCISES }
+    return { foregone, deprecated: NO_EXERCISES }
   }
 
   return exercises.reduce(


### PR DESCRIPTION
Several typos were fixed. The reader was instructed to go write a "versions" key to the .json file, at certain points. These now correctly direct the reader to add a "versioning" key, like the README does. I kept the grammar refinements as relatively minimal, but I did implement some where I deemed it as critical.

`yarn test` passes.