### PR TITLE
identify stub_file key correctly in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ replacements:
 
 ## Stub tracking
 
-Add a `versioning` key to `/src/data/tracks.json`. The value is _not_ a
+Add a `stub_file` key to `/src/data/tracks.json`. The value is _not_ a
 regular expression or glob pattern, but allows for very specific template
 replacements. Same as Track Versioning.
 


### PR DESCRIPTION
`stub` -> `versioning` -> `stub_file`, in README

In spite of going over them a couple times myself, once actually merged, I noted an error in the changes introduced, upon after-review. It was also technically off two versions ago, also, but er, oops.