### PR TITLE
Update `ExerciseSlug` format for Kotlin.

### DIFF
--- a/src/data/tracks.json
+++ b/src/data/tracks.json
@@ -216,8 +216,8 @@
     "name": "Kotlin",
     "core_enabled": true,
     "versioning": "exercises/{slug}/.meta/version",
-    "stub_file": "exercises/{slug}/src/main/kotlin/{Exerciseslug}.kt",
-    "test_file": "exercises/{slug}/test/main/kotlin/{Exerciseslug}Test.kt"
+    "stub_file": "exercises/{slug}/src/main/kotlin/{ExerciseSlug}.kt",
+    "test_file": "exercises/{slug}/test/main/kotlin/{ExerciseSlug}Test.kt"
   },
   {
     "slug": "lfe",


### PR DESCRIPTION
Fix for #43.