### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+## 0.6.2
+
 - Add `versioning` for `d`
 - Fix `versioning` for `kotlin`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exercism/tracks-maintenance-dashboard",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Tool for maintainers and track contributors",
   "license": "MIT",
   "author": "Derk-Jan Karrenbeld <derk-jan+git@karrenbeld.info>",


### PR DESCRIPTION
Release changelog:

```
  - Add versioning for `d`.
  - Fix versioning for `kotlin`.
```

Tag: `v0.6.2` (Can't be pushed with PR, unfortunately).