### PR TITLE
Update pattern for Nim test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+## 0.8.1
+
+- Update test pattern for Nim
+
 ## 0.8.0
 
 - Work with post-boom track configs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exercism/tracks-maintenance-dashboard",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Tool for maintainers and track contributors",
   "license": "MIT",
   "author": "Derk-Jan Karrenbeld <derk-jan+git@karrenbeld.info>",

--- a/src/data/tracks.json
+++ b/src/data/tracks.json
@@ -237,7 +237,7 @@
     "slug": "nim",
     "name": "Nim",
     "core_enabled": true,
-    "versioning": "exercises/practice/{slug}/{exercise_slug}_test.nim",
+    "versioning": "exercises/practice/{slug}/test_{exercise_slug}.nim",
     "stub_file": "exercises/practice/{slug}/{exercise_slug}.nim",
     "test_file": "{versioning}"
   },


### PR DESCRIPTION
The `test` now comes first.

See:
- https://exercism.io/tracks/nim/tests
- https://github.com/exercism/nim/commit/573ee59fa9530d1d625bf3c265429fe4c25e3fd3